### PR TITLE
Added support for @owl_channel annotation

### DIFF
--- a/interpreters/pd2hv/PdReceiveObject.py
+++ b/interpreters/pd2hv/PdReceiveObject.py
@@ -65,6 +65,7 @@ class PdReceiveObject(PdObject):
             except:
                 pass
 
+
             if not (self.__attributes["min"] <= self.__attributes["default"]):
                 self.add_error("Default parameter value is less than the minimum. Receiver will not be exported: {0:g} < {1:g}".format(
                     self.__attributes["default"],
@@ -75,6 +76,10 @@ class PdReceiveObject(PdObject):
                     self.__attributes["default"],
                     self.__attributes["max"]))
                 self.__extern_type = None
+
+        if '@owl_channel' in self.obj_args:
+            i = self.obj_args.index('@owl_channel')
+            self.__attributes["owl_channel"] = self.obj_args[i+1]
 
     def validate_configuration(self):
         if self.obj_type in ["r~", "receive~"]:

--- a/interpreters/pd2hv/PdSendObject.py
+++ b/interpreters/pd2hv/PdSendObject.py
@@ -38,6 +38,10 @@ class PdSendObject(PdObject):
         except:
             pass
 
+        if '@owl_channel' in self.obj_args:
+            i = self.obj_args.index('@owl_channel')
+            self.__attributes["owl_channel"] = self.obj_args[i+1]
+
     def validate_configuration(self):
         if len(self.obj_args) == 0:
             self.add_warning(


### PR DESCRIPTION
The changes here are minimal, we just need to detect the annotation @owl_channel and place it in the generated IR json file.

The annotation should mark the owl channel that need to be connected to the receive/send element (ie: Channel-E). 

The reason why I have decided to add an annotation for the channel name and not for the label, is that if we ever want to use also the @hv_param annotation, it does not accept receivers with a dash in the name, and all owl channel names have dashes in them.